### PR TITLE
Depl stack: fix perms; main stack: simplify; README: revise

### DIFF
--- a/10-minute-aws-client-vpn-prereq.yaml
+++ b/10-minute-aws-client-vpn-prereq.yaml
@@ -2,7 +2,7 @@
 AWSTemplateFormatVersion: "2010-09-09"
 
 Description: |-
-  Deployment role for
+  CloudFormation service role to deploy
 
   github.com/sqlxpert/10-minute-aws-client-vpn  GPLv3  Copyright Paul Marcelin
 
@@ -12,16 +12,20 @@ Parameters:
     Type: String
     Default: "https://github.com/sqlxpert/10-minute-aws-client-vpn"
 
+  PlaceholderSuggestedStackName:
+    Type: String
+    Default: "CVpnPrereq"
+
   StackNameBase:
     Type: String
     Description: >-
-      When using the DeploymentRole provided by this stack, you MUST include
-      this string in the name of any VPN stack that you create. For security,
-      no other CloudFormation stack or StackSet's name should include this
-      string. You may add prefixes and suffixes to your future stack's name.
-      For example, if you set this to "CVpn", you can alternate between a
-      "CVpn1" stack and a "CVpn2" stack for blue/green deployment of updates,
-      or you can create a "TestCVpn" stack marked for testing.
+      String that must be in the name of any CloudFormation stack created
+      using the deployment role. For security, do not include this string in
+      the name of unrelated stacks or StackSets. You may add refixes or
+      suffixes when naming a stack created using the deployment role. For
+      example, if you specify "CVpn", you can alternate between "CVpn1" and
+      "CVpn2" stacks for blue/green updates, and you can reate a "TestCVpn"
+      stack for testing.
     Default: "CVpn"
 
 Metadata:
@@ -29,13 +33,19 @@ Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
-          default: Essentials
+          default: For Reference
         Parameters:
           - PlaceholderHelp
+          - PlaceholderSuggestedStackName
+      - Label:
+          default: Essential
+        Parameters:
           - StackNameBase
     ParameterLabels:
       PlaceholderHelp:
         default: For help with this stack, see
+      PlaceholderSuggestedStackName:
+        default: Suggested stack name
       StackNameBase:
         default: >-
           Name of future stack
@@ -70,7 +80,11 @@ Resources:
                   - logs:DeleteLogGroup
                   - logs:PutRetentionPolicy
                   - logs:DeleteRetentionPolicy
+                  - logs:ListTagsForResource
+                  - logs:TagResource
                   - logs:TagLogGroup
+                  - logs:UntagLogGroup
+                  - logs:UntagResource
                   - logs:CreateLogStream
                   - logs:DescribeLogStreams
                 Resource:
@@ -93,19 +107,31 @@ Resources:
                   - kms:DescribeKey
                 Resource: "*"
 
-              - Effect: Allow
+              - Sid: WarningAllSecGrpsNotOnlyStackRelated
+                Effect: Allow
                 Action:
                   - ec2:CreateTags
-                  - ec2:DeleteTags  # Due to stack tag propagation
+                  - ec2:RevokeSecurityGroupEgress
+                Resource:
+                  - !Sub "arn:${AWS::Partition}:ec2:*:${AWS::AccountId}:security-group/*"
+                  # Cannot check aws:ResourceTag/aws:cloudformation:stack-name
+                  # 1. Before a new security group is tagged
+                  # 2. If creating a security group without an egress rule
+                  #    (because AWS removes the default all-egress rule before
+                  #    tagging the new security group!)
+              - Effect: Allow
+                Action:
+                  - ec2:DeleteTags
                 Resource:
                   - !Sub "arn:${AWS::Partition}:ec2:*:${AWS::AccountId}:security-group/*"
                 Condition:
                   StringLike:
                     aws:ResourceTag/aws:cloudformation:stack-name: !Sub "*${StackNameBase}*"
-              - Sid: WarningAllResourcesNotOnlyStackRelated
+              - Sid: WarningAllSecGrpRulesAndVpnEndpointsNotOnlyStackRelated
                 Effect: Allow
                 Action:
                   - ec2:CreateTags
+                  - ec2:DeleteTags
                 Resource:
                   - !Sub "arn:${AWS::Partition}:ec2:*:${AWS::AccountId}:security-group-rule/*"
                   - !Sub "arn:${AWS::Partition}:ec2:*:${AWS::AccountId}:client-vpn-endpoint/*"
@@ -130,7 +156,6 @@ Resources:
                   - ec2:AuthorizeSecurityGroupEgress
                   - ec2:ModifySecurityGroupRules
                   - ec2:RevokeSecurityGroupIngress
-                  - ec2:RevokeSecurityGroupEgress
                   - ec2:DeleteSecurityGroup
                 Resource:
                   - !Sub "arn:${AWS::Partition}:ec2:*:${AWS::AccountId}:security-group/*"
@@ -152,10 +177,11 @@ Resources:
                   - ec2:DescribeVpcs
                 Resource: "*"
 
-              - Sid: WarningAllParametersNotOnlyStackRelated
+              - Sid: WarningAllSsmParamsNotOnlyStackRelated
                 Effect: Allow
                 Action:
                   - ssm:PutParameter
+                  - ssm:ListTagsForResource
                   - ssm:AddTagsToResource
                 Resource:
                   - !Sub "arn:${AWS::Partition}:ssm:*:${AWS::AccountId}:parameter/*"
@@ -164,7 +190,7 @@ Resources:
                   - ssm:GetParameter
                   - ssm:GetParameters
                   - ssm:LabelParameterVersion
-                  - ssm:RemoveTagsFromResource  # Due to stack tag propagation
+                  - ssm:RemoveTagsFromResource
                   - ssm:DeleteParameter
                   - ssm:DeleteParameters
                 Resource:
@@ -179,8 +205,9 @@ Resources:
 
               # Meaningless ID numbers in AWS Client VPN Endpoint ARNs, and
               # lack of standard CloudFormation tags (stack-name, etc.),
-              # prevents restricting scope of deployment role to just the
-              # endpoint defined in the future stack
+              # prevents restricting the scope of the deployment role to just
+              # the endpoint defined in a stack created using the deployment
+              # role.
               - Effect: Allow
                 Action:
                   - ec2:CreateClientVpnEndpoint
@@ -218,13 +245,13 @@ Resources:
                   - ec2:DescribeClientVpn*
                 Resource: "*"
 
-              # CloudFormation stack tag propagation is a blessing and a
-              # curse. Because the CVpn stack is intended to have
-              # sched-set-Enable-true and sched-set-Enable-false stack tags,
-              # CloudFormation needs to be able to create, modify and delete
-              # tags on all child resources. Policy changes will be necessary
-              # if CloudFormation begins supporting tag propagation for more
-              # resource types.
+                # CloudFormation stack tag propagation is a blessing and a
+                # curse. Because the CVpn stack is intended to have
+                # sched-set-Enable-true and sched-set-Enable-false stack tags,
+                # CloudFormation needs to be able to get/list, create, modify
+                # and delete tags on all child resources. Policy changes may
+                # be necessary if CloudFormation begins supporting tag
+                # propagation for more resource types.
 
   SampleDeploymentRolePassRolePol:
     Type: "AWS::IAM::ManagedPolicy"

--- a/10-minute-aws-client-vpn.yaml
+++ b/10-minute-aws-client-vpn.yaml
@@ -12,6 +12,10 @@ Parameters:
     Type: String
     Default: "https://github.com/sqlxpert/10-minute-aws-client-vpn"
 
+  PlaceholderSuggestedStackName:
+    Type: String
+    Default: "CVpn"
+
   Enable:
     Type: String
     Description: >-
@@ -20,64 +24,17 @@ Parameters:
       to "false" whenever the VPN is not needed; AWS charges for associations
       even when no clients are connected. (Re)creating VPN associations takes
       several minutes. To delete and recreate on a schedule, see
-      https://github.com/sqlxpert/lights-off-aws
+      https://github.com/sqlxpert/lights-off-aws#bonus-delete-and-recreate-expensive-resources-on-a-schedule
     AllowedValues:
       - "false"
       - "true"
     Default: "true"
-
-  VpcId:
-    Type: AWS::EC2::VPC::Id
-    Description: >-
-      The ID of the AWS VPC to which you will connect
-
-  DestinationIpv4CidrBlock:
-    Type: String
-    Description: >-
-      The range of private IPv4 addresses that VPN clients can reach, in CIDR
-      notation. Set to the VPC's address range; this "split-tunnel" VPN routes
-      other traffic through a client's regular network connection.
-
-  ClientIpv4CidrBlock:
-    Type: String
-    Description: >-
-      The (non-overlapping) range of private IPv4 addresses available for VPN
-      clients, in CIDR notation. It must contain between 1024 ( /22 ) and 1
-      million ( /12 ) addresses. Accept the default if your AWS VPC and
-      home/office local-area network (LAN) address ranges are in 172.16.X.X or
-      192.168.X.X, or they do not extend all the way to the end of 10.X.X.X.
-      Change if your VPC or LAN covers 10.0.0.0/8 ( 10.0.0.0 – 10.255.255.255
-      ) or an upper portion such as 10.128.0.0/9 ( 10.128.0.0 – 10.255.255.255
-      ).
-    Default: "10.255.252.0/22"
-
-  TargetSubnetId:
-    Type: AWS::EC2::Subnet::Id
-    Description: >-
-      The ID of the primary subnet with which your VPN will be associated. It
-      must be in the designated VPC, must contain at least 32 addresses ( /27
-      or a lower number of subnet bits, indicating more addresses), and must
-      have at least 8 available IP addresses. See
-      https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/cvpn-working-target.html#cvpn-working-target-associate
-
-  BackupTargetSubnetId:
-    Type: String  # List<AWS::EC2::Subnet::Id> cannot be empty
-    Description: >-
-      The ID of a backup subnet. This one must cover a different
-      availability zone. Leave blank for a VPN that costs less but cannot
-      accommodate the failure of its sole AWS availability zone.
 
   ServerCertificateArn:
     Type: String
     Description: >-
       The TLS certificate for the VPN server. Specify the ARN of an AWS
       Certificate Manager certificate.
-
-  PlaceholderAdvancedParameters:
-    Type: String
-    Default: ""
-    AllowedValues:
-      - ""
 
   ClientRootCertificateChainArn:
     Type: String
@@ -87,6 +44,63 @@ Parameters:
       certificate, in which case a client with any certificate from the same
       certificate authority (CA) can connect.
     Default: ""
+
+  VpcId:
+    Type: AWS::EC2::VPC::Id
+    Description: >-
+      The ID of the AWS Virtual Private Cloud (VPC) to which the Virtual
+      Private Network (VPN) will connect
+
+  DestinationIpv4CidrBlock:
+    Type: String
+    Description: >-
+      The range of private IPv4 addresses that VPN clients can reach, in CIDR
+      notation. (This "split-tunnel" VPN routes other traffic through a
+      client's regular network connection.) Set to the VPC's address range. If
+      you are using CloudFormation in the AWS Console, reopen the VPC pop-up
+      menu, immediately above, to see the address range of the VPC you
+      specified.
+
+  TargetSubnetId:
+    Type: AWS::EC2::Subnet::Id
+    Description: >-
+      The ID of the primary subnet with which your VPN will be associated. It
+      must be in the VPC you specified, must contain at least 32 IP addresses
+      ( /27 or fewer subnet bits, indicating more addresses), and must have at
+      least 8 available addresses. See
+      https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/cvpn-working-target.html#cvpn-working-target-associate
+      . If you are using CloudFormation in the AWS Console, look above to see
+      the Destination IP address range you specified. The Primary subnet
+      pop-up menu shows subnet address ranges. Choose a subnet within the
+      Destination IP address range. (If you have multiple VPCs with
+      overlapping address ranges, check separately that the Subnet ID
+      represents a subnet in the VPC you specified.)
+
+  BackupTargetSubnetId:
+    Type: String  # List<AWS::EC2::Subnet::Id> cannot be empty
+    Description: >-
+      The ID of a backup subnet. This one must cover a different
+      availability zone. Leave blank for a VPN that costs less but cannot
+      accommodate the failure of its sole AWS availability zone.
+
+  ClientIpv4CidrBlock:
+    Type: String
+    Description: >-
+      The non-overlapping range of private IPv4 addresses available for VPN
+      clients, in CIDR notation. It must contain between 1024 and 1 million
+      addresses (that is, between /22 and /12 subnet bits). Accept the default
+      if your AWS VPC and your home/office local-area network (LAN) address
+      ranges are in 172.16.X.X or 192.168.X.X, or they do not go all the way
+      to the end of 10.X.X.X. Change if your VPC or LAN covers all of
+      10.0.0.0/8 (10.0.0.0 to 10.255.255.255), or a final part such as
+      10.128.0.0/9 (10.128.0.0 to 10.255.255.255).
+    Default: "10.255.252.0/22"
+
+  PlaceholderAdvancedParameters:
+    Type: String
+    Default: ""
+    AllowedValues:
+      - ""
 
   ProtocolAndPort:
     Type: String
@@ -120,7 +134,7 @@ Parameters:
       block traffic from VPN clients to the VPC. If the generic groups do not
       meet your needs, specify the IDs of 1 or more security groups to which
       VPN clients should be assigned. Separate multiple IDs with commas (no
-      spaces). Groups must be in the designated VPC.
+      spaces). Groups must be in the VPC you specified.
     Default: ""
 
   ClientSecGrpIdParamPath:
@@ -149,11 +163,17 @@ Parameters:
   CloudWatchLogsKmsKey:
     Type: String
     Description: >-
-      If blank, logs will receive default non-KMS CloudWatch Logs encryption.
-      To use a KMS key, which must be a custom key, specify an ARN with the
-      key ID, not an alias. You MUST first give CloudWatch Logs access to the
-      key by editing the key's key policy. See
+      If this is blank, default non-KMS CloudWatch Logs encryption applies. To
+      use a KMS key, which must be a custom key, specify "ACCOUNT:key/KEY_ID".
+      Whether the custom key is a single-region key, a multi-region key
+      primary, or a multi-region key replica, it must be in the same region
+      where you are creating this stack. Even if the custom key is in the same
+      AWS account as this stack, you must update the key policy to allow usage
+      by CloudWatch Logs. See
       https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html#cmk-permissions
+      . For a StackSet, the custom key must be multi-region ("mrk-" prefix in
+      the KEY_ID), and a replica (or the primary key itself) must exist in
+      every target region.
     Default: ""
 
 Metadata:
@@ -161,21 +181,28 @@ Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
-          default: Essentials
+          default: For Reference
         Parameters:
           - PlaceholderHelp
+          - PlaceholderSuggestedStackName
+      - Label:
+          default: Essential
+        Parameters:
           - Enable
+          - ServerCertificateArn
           - VpcId
           - DestinationIpv4CidrBlock
-          - ClientIpv4CidrBlock
           - TargetSubnetId
-          - BackupTargetSubnetId
-          - ServerCertificateArn
+          - ClientIpv4CidrBlock
       - Label:
           default: Advanced Options
         Parameters:
           - PlaceholderAdvancedParameters
+      - Label:
+          default: Virtual Private Network
+        Parameters:
           - ClientRootCertificateChainArn
+          - BackupTargetSubnetId
           - ProtocolAndPort
           - DnsServerIpv4Addr
       - Label:
@@ -192,6 +219,8 @@ Metadata:
     ParameterLabels:
       PlaceholderHelp:
         default: For help with this stack, see
+      PlaceholderSuggestedStackName:
+        default: Suggested stack name
       Enable:
         default: Enabled?
       VpcId:
@@ -207,7 +236,7 @@ Metadata:
       ServerCertificateArn:
         default: Server certificate
       PlaceholderAdvancedParameters:
-        default: Do not change parameters below this line unless necessary!
+        default: Do not change parameters below, unless necessary!
       ClientRootCertificateChainArn:
         default: Client certificate (optional)
       ProtocolAndPort:
@@ -341,7 +370,7 @@ Resources:
         Fn::If:
           - CloudWatchLogsKmsKeyBlank
           - !Ref AWS::NoValue
-          - !Ref CloudWatchLogsKmsKey
+          - !Sub "arn:${AWS::Partition}:kms:${AWS::Region}:${CloudWatchLogsKmsKey}"
 
   LogStream:
     Type: AWS::Logs::LogStream

--- a/README.md
+++ b/README.md
@@ -48,30 +48,25 @@ types of charges may also apply.
 ## Quick Installation
 
  1. Follow AWS's
-    [mutual authentication steps](https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/client-auth-mutual-enable.html),
-    which help you create TLS certificates for the VPN server and for clients,
-    and to upload the server certificate to AWS Certificate Manager.
+    [mutual authentication steps](https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/client-auth-mutual-enable.html).
 
     Copy the individual Linux/macOS commands and execute them verbatim.
 
-    Copy and edit the block of commands before running those.
-    `~/custom_folder` is fine for now, but after the `mkdir` line, do insert:
+    Copy and edit the block of commands before executing those.
+    `~/custom_folder` is fine for now, but after the `mkdir` line, insert:
 
     ```bash
     chmod go= ~/custom_folder
     ```
 
-    to help protect the certificates.
-
-    After uploading the first (server) certificate, copy the ARN that ACM
-    returns.
-
-    There is no need to upload the second (client) certificate.
+    After uploading the first (server) certificate, copy the ARN returned by
+    AWS Certificate Manager. There is no need to upload the second (client)
+    certificate.
 
  2. _Optional:_ You can use a
     [CloudFormation service role](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-servicerole.html)
     to delegate only the privileges needed to deploy a Client VPN stack.
-    Create a from a locally-saved copy of
+    Create a stack from a locally-saved copy of
     [10-minute-aws-client-vpn-prereq.yaml](/10-minute-aws-client-vpn-prereq.yaml?raw=true)
     [right-click to save as...]. Name the stack `CVpnPrereq` .
 
@@ -86,7 +81,6 @@ types of charges may also apply.
     Name the stack `CVpn` .
 
     The parameters are thoroughly documented. Set only the Essential ones.
-    Ignore the Advanced Options.
 
     _Optional:_ If you created the deployment role in the previous step, set
     IAM role - optional to `CVpnPrereq-DeploymentRole` later in the `CVpn`
@@ -152,9 +146,8 @@ types of charges may also apply.
 
 ## Automatic Scheduling
 
-1. Be sure that you have completed the optional parts of
-   [Quick Installation](#quick-installation)
-   Steps 2 and 3.
+1. Be sure that you have completed the optional parts of the
+   [Quick Installation](#quick-installation) procedure.
 
 2. [Install Lights Off](https://github.com/sqlxpert/lights-off-aws#quick-start).
 
@@ -172,8 +165,8 @@ types of charges may also apply.
      helpful:
      [www.timeanddate.com](https://www.timeanddate.com/worldclock/converter.html?iso=20250320T140000&p1=224&p2=250&p3=1440&p4=37&p5=44)
      .
-   - UTC has no provision for Daylight Saving Time or Summer Time. Leave a
-     1-hour buffer after your work day to avoid having to change schedules.
+   - UTC has no provision for Daylight Saving Time/Summer Time. Leave a
+     buffer after your work day to avoid having to change schedules.
 
 4. Find your VPN in the list of
    [Client VPN endpoints](https://console.aws.amazon.com/vpc/home#ClientVPNEndpoints:search=ClientVpnEndpoint)
@@ -185,14 +178,14 @@ types of charges may also apply.
 
 You can change the `Enable` parameter whenever you wish.
 
-You can add or remove a backup subnet (for a backup Availability Zone) even
+You can add or remove a backup subnet (for a second Availability Zone) even
 while the VPN is enabled. You can also switch between generic and custom
 security groups.
 
 Do not try to change the VPC, the destination or client IP address ranges, or
-the paths, after you have created the `CVpn` stack. To choose different values
-for those parameters, create a `CVpn2` stack and then delete your original
-`CVpn` stack.
+the paths, after you have created the `CVpn` stack. Instead, create a `CVpn2`
+stack and then delete your original `CVpn` stack; distributing a new VPN
+client configuration is required.
 
 ## Feedback
 

--- a/README.md
+++ b/README.md
@@ -5,22 +5,23 @@
 This CloudFormation template will help you set up an AWS-managed VPN in about
 10 minutes and operate it for as little as $1 per day!
 
-Security experts discourage relying mainly on the strength of the perimeter
-around your private network, but sometimes, perimeter security _is_ the
-available defense, and a virtual private network connection is necessary. For
-example, to access an AWS Elastic File System (EFS) volume from your local
-computer, you must use a VPN, so that the Network File System (NFS) client
-connection originates _inside_ your AWS Virtual Private Cloud (VPC). NFS
-server software was not designed for full exposure to the public Internet.
+Experts discourage relying on the strength of the perimeter around your
+private network, but sometimes, perimeter security _is_ the available defense,
+and a virtual private network connection is necessary. For example, to access
+an AWS Elastic File System (EFS) volume from your local computer, you must use
+a VPN, so that the Network File System (NFS) client connection originates
+_inside_ your AWS Virtual Private Cloud (VPC). NFS server software was not
+designed for exposure to the public Internet.
 
-Client VPN is convenient because AWS manages it for you. It's
+Client VPN is convenient because AWS manages it for you. It is
 [well-documented](https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/what-is.html),
 but there are pitfalls for new users.
-[Client VPN is also expensive](https://aws.amazon.com/vpn/pricing/#AWS_Client_VPN_pricing).
+
+[Client VPN is expensive](https://aws.amazon.com/vpn/pricing/#AWS_Client_VPN_pricing).
 The baseline charge of 10¢ per hour per associated Availability Zone amounts
 to $876 per year. Add 5¢ per hour per connection. Assuming a 40-hour work week,
-that's $104 per year per person, for a minimum total cost of $876 + $104 = $980
-per year. At least AWS now throws in
+that is $104 per year per person, for a minimum total cost of $876 + $104 =
+$980 per year. At least AWS now throws in
 [free Client VPN data transfer between Availability Zones](https://aws.amazon.com/about-aws/whats-new/2022/04/aws-data-transfer-price-reduction-privatelink-transit-gateway-client-vpn-services/)!
 
 The template minimizes costs by:
@@ -28,105 +29,109 @@ The template minimizes costs by:
 1. Associating the VPN with one Availability Zone. (Clients can access
    resources in any zone.) Failure of the designated zone would temporarily
    disable the VPN. You can associate a second zone for redundancy, if you
-   don't mind the extra cost.
+   do not mind the extra cost.
 
 2. Configuring a "split-tunnel" VPN, which carries only private network (VPC)
-   traffic. A client's regular network connection handles public Internet
-   traffic. For simplicity, the template does not support a "full tunnel"
-   configuration.
+   traffic. Your regular Internet connection handles public Internet traffic.
 
 3. Optionally supporting
-   [Lights Off](https://github.com/sqlxpert/lights-off-aws),
-   which can turn the VPN on and off automatically. For example, leaving the
-   VPN on 10 hours every weekday but shutting it off overnight and on weekends
-   reduces the baseline cost from $876 to $261. With one person working 8
-   hours per weekday, the minimum total cost drops to $261 + $104 = $365 per
-   year.
+   [Lights Off](https://github.com/sqlxpert/lights-off-aws#bonus-delete-and-recreate-expensive-resources-on-a-schedule),
+   which can turn the VPN on and off automatically. Leaving the VPN on for 10
+   hours every weekday but shutting it off overnight and on weekends reduces
+   the baseline cost to $261. With one person connecting for 8 hours per
+   weekday, the minimum total cost drops to $261 + $104 = $365 per year.
 
-Prices for the US East 1 (Northern Virginia) region were checked October 1,
-2022. Prices and pricing rules can change at any time. NAT gateway, data
-transfer, and other types of charges may also apply.
+Prices for the US East 1 (Northern Virginia) region were checked March 20,
+2025. Pricing can change at any time. NAT gateway, data transfer, and other
+types of charges may also apply.
 
 ## Quick Installation
 
  1. Follow AWS's
-    [mutual authentication](https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/client-authentication.html#mutual)
-    steps, which help you create TLS certificates for the VPN server and for
-    clients, and to upload the server certificate to AWS Certificate Manager.
+    [mutual authentication steps](https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/client-auth-mutual-enable.html),
+    which help you create TLS certificates for the VPN server and for clients,
+    and to upload the server certificate to AWS Certificate Manager.
 
-    Copy the Linux/macOS commands and execute them verbatim.
+    Copy the individual Linux/macOS commands and execute them verbatim.
 
-    If you don't mind storing your certificates in `~/custom_folder/` and
-    renaming the folder later, even those commands can be executed verbatim. I
-    do, however, recommend inserting
+    Copy and edit the block of commands before running those.
+    `~/custom_folder` is fine for now, but after the `mkdir` line, do insert:
 
     ```bash
-    chmod go= ~/custom_folder/
+    chmod go= ~/custom_folder
     ```
 
-    immediately after the `mkdir` line.
+    to help protect the certificates.
 
-    Copy the ARN that ACM assigns when you upload the server certificate.
-    There is no need to upload the client certificate to ACM.
+    After uploading the first (server) certificate, copy the ARN that ACM
+    returns.
 
- 2. Optional: You can use a
+    There is no need to upload the second (client) certificate.
+
+ 2. _Optional:_ You can use a
     [CloudFormation service role](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-servicerole.html)
-    to give CloudFormation only the privileges it needs to create a Client VPN
-    stack. Create a stack named `CVpnPrereq` from
-    [10-minute-aws-client-vpn-prereq.yaml](/10-minute-aws-client-vpn-prereq.yaml)
-    . You _must_ do this if you plan to use Lights Off to turn the VPN on and
-    off automatically.
+    to delegate only the privileges needed to deploy a Client VPN stack.
+    Create a from a locally-saved copy of
+    [10-minute-aws-client-vpn-prereq.yaml](/10-minute-aws-client-vpn-prereq.yaml?raw=true)
+    [right-click to save as...]. Name the stack `CVpnPrereq` .
 
- 3. Create a CloudFormation stack from
-    [10-minute-aws-client-vpn.yaml](/10-minute-aws-client-vpn.yaml)
-    .
+    This step is _required_ if you plan to use
+    [Lights Off](https://github.com/sqlxpert/lights-off-aws#bonus-delete-and-recreate-expensive-resources-on-a-schedule)
+    to turn the VPN on and off on a schedule.
+
+ 3. Create a CloudFormation stack from a locally-saved copy of
+    [10-minute-aws-client-vpn.yaml](/10-minute-aws-client-vpn.yaml?raw=true)
+    [right-click to save as...].
 
     Name the stack `CVpn` .
 
-    The parameters are thoroughly documented. Set only the ones in the
-    Essentials section. Make no changes under Advanced Options.
+    The parameters are thoroughly documented. Set only the Essential ones.
+    Ignore the Advanced Options.
 
-    Optional: If you created the deployment role in the previous step, set IAM
-    role - optional to `CVpnPrereq-DeploymentRole` during the `CVpn` stack
-    creation process. (If your own privileges are limited, you might need
-    explicit permission to pass the deployment role to CloudFormation. See the
-    `CVpnPrereq-SampleDeploymentRolePassRolePol` IAM policy for an example of
-    the necessary statement.)
+    _Optional:_ If you created the deployment role in the previous step, set
+    IAM role - optional to `CVpnPrereq-DeploymentRole` later in the `CVpn`
+    stack creation process. (If your own privileges are limited, you might
+    need explicit permission to pass the role to CloudFormation. See the
+    `CVpnPrereq-SampleDeploymentRolePassRolePol` IAM policy for an example.)
 
  4. Follow
-    [Step 7 of AWS's Getting Started document](https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/cvpn-getting-started.html#cvpn-getting-started-config)
-    , which helps you download and edit the VPN client configuration file.
+    [Step 7 of AWS's Getting Started document](https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/cvpn-getting-started.html#cvpn-getting-started-config).
 
     You must find your VPN in the list of
     [Client VPN endpoints](https://console.aws.amazon.com/vpc/home#ClientVPNEndpoints:search=ClientVpnEndpoint)
-    in the VPC Console and download the configuration file from there. (No
-    self-service portal page is available for a VPN that relies on mutual
-    certificate-based authentication.)
+    in the AWS Console and download the configuration file from there.
 
-    When inserting the certificate and key into the configuration file, copy
-    only the portion of each that begins with `-----BEGIN CERTIFICATE-----`
-    and ends with `-----END CERTIFICATE-----` (including those lines).
+    `cd` to the directory where you downloaded the file and:
 
-    Do not forget to prepend a random string to the Client VPN endpoint DNS
-    name. That line of the configuration file begins with `remote` .
+    ```bash
+    chmod go= downloaded-client-config.ovpn
+    ```
 
- 5. Download either the
-    [OpenVPN](https://openvpn.net)
-    client (Products &rarr; Connect Client)
-    or the
-    [AWS client](https://aws.amazon.com/vpn/client-vpn-download/)
-    .
+    Open the file in your preferred editor, copy the skeleton from AWS's
+    instructions and paste it at the end of the file, then replace the text
+    between the tags with the contents of the
+    `~/custom_folder/client1.domain.tld.crt` certificate file and the
+    `~/custom_folder/client1.domain.tld.key` key file.
 
-    The disclosure for the AWS client reveals that AWS collects usage data.
-    I do not know whether OpenVPN also collects data.
+    Rename `~/custom_folder` and note that you must also continue to protect
+    `easy-rsa/easyrsa3/pki` and `downloaded-client-config.ovpn` , all of which
+    contain copies of your key.
+
+ 5. Download either the latest
+    [OpenVPN](https://openvpn.net) client (Resources &rarr; Connect Client
+    &rarr; Download) or
+    [AWS client](https://aws.amazon.com/vpn/client-vpn-download/).
+
+    It is not known whether OpenVPN collects data. The download page for the
+    AWS client reveals that AWS collects usage data.
 
  6. Import your edited configuration file to the client.
 
  7. Use the client to connect to the VPN.
 
- 8. Add `FromClientSampleSecGrp` to an EC2 instance or, if you don't use SSH,
+ 8. Add `FromClientSampleSecGrp` to an EC2 instance or, if you do not use SSH,
     create and add a security group that accepts traffic from VPN clients on
-    the port of your choice.
+    another port of your choice.
 
  9. Test. On your local computer, run:
 
@@ -138,7 +143,7 @@ transfer, and other types of charges may also apply.
     SSH key pair, and _IP_ADDRESS_ is the **private** address of the instance.
 
     Different operating system images have different
-    [default user names](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/connection-prereqs.html#connection-prereqs-get-info-about-instance);
+    [default usernames](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/connection-prereqs-general.html#connection-prereqs-get-info-about-instance);
     `ec2-user` is not always correct!
 
     If you do not use SSH, run a different command to test VPN connectivity.
@@ -156,16 +161,23 @@ transfer, and other types of charges may also apply.
 3. Update your `CVpn` CloudFormation stack, adding the following stack-level
    tags:
 
-   * `sched-set-Enable-true` : `d=01 d=02 d=03 d=04 d=05 H:M=14:00`
-   * `sched-set-Enable-false` : `d=02 d=03 d=04 d=05 d=06 H:M=01:00`
+   - `sched-set-Enable-true` : `d=01 d=02 d=03 d=04 d=05 H:M=14:00`
+   - `sched-set-Enable-false` : `d=02 d=03 d=04 d=05 d=06 H:M=01:00`
 
-   Modify these schedules according to your own work days and work hours,
-   keeping in mind that the schedules are in UTC time _and_ that UTC has no
-   provision for Daylight Saving Time.
+   Adjust the weekdays and the times based on your work schedule.
+
+   - `u=1` is Monday and `u=7` is Sunday, per
+     [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Week_dates).
+   - Times are in Universal Coordinated Time (UTC). This converter may be
+     helpful:
+     [www.timeanddate.com](https://www.timeanddate.com/worldclock/converter.html?iso=20250320T140000&p1=224&p2=250&p3=1440&p4=37&p5=44)
+     .
+   - UTC has no provision for Daylight Saving Time or Summer Time. Leave a
+     1-hour buffer after your work day to avoid having to change schedules.
 
 4. Find your VPN in the list of
    [Client VPN endpoints](https://console.aws.amazon.com/vpc/home#ClientVPNEndpoints:search=ClientVpnEndpoint)
-   in the VPC Console and check that its Target network association(s) are
+   in the AWS Console and check that its Target network association(s) are
    being created and deleted as scheduled. After a few days of operation,
    check actual costs.
 
@@ -184,10 +196,10 @@ for those parameters, create a `CVpn2` stack and then delete your original
 
 ## Feedback
 
-To help improve the 10-minute AWS Client VPN template, please submit
-[bug reports and feature requests](https://github.com/sqlxpert/10-minute-aws-client-vpn/issues),
-as well as
-[proposed changes](https://github.com/sqlxpert/10-minute-aws-client-vpn/pulls).
+To help improve the 10-minute AWS Client VPN template, please
+[report bugs](https://github.com/sqlxpert/10-minute-aws-client-vpn/issues)
+and
+[propose changes](https://github.com/sqlxpert/10-minute-aws-client-vpn/pulls).
 
 ## Licenses
 


### PR DESCRIPTION
- Add permissions to CFn deployment role, covering: creation of main stack with stack tags upon creation; creation of security groups with no egress rule; resource tagging
- Simplify parameter sections, order, and descriptions for both stacks
- Support multi-region custom KMS keys for CloudWatch Logs
- Revise README based on AWS's latest Client VPN instructions, and an update to the OpenVPN Connect client or a change to AWS's configuration file (random remote host name)

- Stack, deployment role, and Lights Off integration tested working 2025-03-20